### PR TITLE
Retire legacy VPS monitoring; point healthcheck at canonical fleet

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,14 +1,8 @@
 name: Deploy to Grudge Studio VPS
 
+# RETIRED: auto-deploy disabled 2026-07-06. Production is grudge-backend + GrudgeBuilder Railway.
+# Manual dispatch only if you intentionally need to touch the legacy VPS stack.
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'services/**'
-      - 'shared/**'
-      - 'docker-compose*.yml'
-      - 'migrations/**'
-      - 'scripts/**'
   workflow_dispatch:
     inputs:
       services:

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,33 +1,34 @@
-name: External Health Check
+name: Fleet Health Check
 
 on:
   schedule:
-    - cron: "*/5 * * * *"  # Every 5 minutes
-  workflow_dispatch: {}     # Manual trigger
+    - cron: "*/30 * * * *"  # Every 30 minutes — canonical fleet endpoints
+  workflow_dispatch: {}
 
 jobs:
   check:
     runs-on: ubuntu-latest
-    timeout-minutes: 2
+    timeout-minutes: 3
     steps:
-      - name: Health check all services
+      - name: Health check canonical Grudge fleet
         id: health
         run: |
           FAIL=0
           REPORT=""
 
+          # SSOT: GrudgeBuilder/shared/fleet/manifest.ts + grudge-backend
+          # This repo (grudge-studio-backend) is retired — do not probe legacy VPS microservices.
           declare -A ENDPOINTS=(
-            [grudge-id]="https://id.grudge-studio.com/health"
-            [game-api]="https://api.grudge-studio.com/health"
-            [account-api]="https://account.grudge-studio.com/health"
-            [launcher-api]="https://launcher.grudge-studio.com/health"
-            [asset-service]="https://assets-api.grudge-studio.com/health"
-            [ws-service]="https://ws.grudge-studio.com/health"
+            [grudge-auth]="https://id.grudge-studio.com/api/health"
+            [grudge-api]="https://api.grudge-studio.com/api/health"
+            [game-data-railway]="https://grudge-api-production-0d46.up.railway.app/api/health"
+            [objectstore]="https://objectstore.grudge-studio.com/health"
+            [ai-gateway]="https://ai.grudge-studio.com/health"
           )
 
           for SVC in "${!ENDPOINTS[@]}"; do
             URL="${ENDPOINTS[$SVC]}"
-            HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 10 "$URL" 2>/dev/null || echo "000")
+            HTTP_CODE=$(curl -sf -o /dev/null -w "%{http_code}" --max-time 15 "$URL" 2>/dev/null || echo "000")
             if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
               echo "  ✅ $SVC ($HTTP_CODE)"
               REPORT="$REPORT\n✅ $SVC"
@@ -44,10 +45,10 @@ jobs:
           echo "EOF" >> $GITHUB_OUTPUT
 
           if [ $FAIL -gt 0 ]; then
-            echo "⚠️ $FAIL service(s) down!"
+            echo "⚠️ $FAIL fleet service(s) down!"
             exit 1
           fi
-          echo "All services healthy!"
+          echo "All canonical fleet services healthy!"
 
       - name: Discord alert on failure
         if: failure() && steps.health.outputs.fail_count != '0'
@@ -61,10 +62,10 @@ jobs:
             -H "Content-Type: application/json" \
             -d "{
               \"embeds\": [{
-                \"title\": \"🚨 Grudge Studio — Services DOWN\",
+                \"title\": \"🚨 Grudge Fleet — Services DOWN\",
                 \"color\": 15158332,
-                \"description\": \"External health check detected ${{ steps.health.outputs.fail_count }} service(s) down:\\n${{ steps.health.outputs.report }}\",
-                \"footer\": {\"text\": \"GitHub Actions external check\"},
+                \"description\": \"Fleet health check detected ${{ steps.health.outputs.fail_count }} service(s) down:\\n${{ steps.health.outputs.report }}\",
+                \"footer\": {\"text\": \"grudge-studio-backend fleet monitor (legacy repo)\"},
                 \"timestamp\": \"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"
               }]
             }"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,13 +1,28 @@
 # Grudge Warlords Era Backend — System Reference (AGENTS.md)
 
-> **Scope:** this repo is the **Grudge Warlords Era game backend + game database** (`grudge_game`),
-> not the generic Grudge Studio company site. `README.md` is the canonical source of truth — if
-> anything here conflicts with it, README wins.
+> **RETIRED (2026-07):** This repo is **not** the live production backend. Agents must use
+> **grudge-backend** (auth/API) and **GrudgeBuilder Railway** (game state Postgres SSOT).
+> Fleet URLs: `GrudgeBuilder/shared/fleet/manifest.ts`. The content below is legacy reference only.
 
-## Single Backend — Always Use These
+## Canonical production (use these, not this repo)
 
-### Auth (ALL apps must use)
-Canonical auth source: `https://id.grudge-studio.com` (the `grudge-id` service in this repo).
+| Service | URL | Repo |
+|---------|-----|------|
+| Auth gateway | `https://id.grudge-studio.com` | grudge-backend |
+| Unified API | `https://api.grudge-studio.com` | grudge-backend |
+| Game state | `https://grudge-api-production-0d46.up.railway.app` | GrudgeBuilder |
+| ObjectStore | `https://objectstore.grudge-studio.com/api/v1` | ObjectStore |
+| Assets CDN | `https://assets.grudge-studio.com` | GrudgeBuilder workers/cdn |
+| AI | `https://ai.grudge-studio.com` | grudge-ai-hub |
+
+Health probes: `/api/health` on auth, api, and Railway; `/health` on objectstore and ai.
+
+---
+
+## Legacy VPS stack (archived — do not deploy)
+
+### Auth (historical — was grudge-id in this repo)
+Legacy auth source: `https://id.grudge-studio.com` (now served by **grudge-backend**, not grudge-id:3001).
 - Issues the Grudge ID JWT consumed by every game service here.
 - Storage keys: `grudge_auth_token` (JWT), `grudge_user_id`, `grudge_id` (UUID), `grudge_username`
 - Legacy Vercel `auth-gateway-*` URLs are retired — do not introduce new auth gateways.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,23 @@
 # Grudge Studio Backend
 
-Full-stack microservices backend for **grudgewarlords.com** and **grudgestudio.com**.
+> **RETIRED (2026-07)** — This VPS microservices stack is no longer production.
+> Use these instead:
+>
+> | Role | Repo | Live URL |
+> |------|------|----------|
+> | Auth + unified API | [grudge-backend](https://github.com/MolochDaGod/grudge-backend) | `id.grudge-studio.com`, `api.grudge-studio.com` |
+> | Game state (SSOT) | [GrudgeBuilder](https://github.com/Grudge-Warlords/GrudgeBuilder) | `grudge-api-production-0d46.up.railway.app` |
+> | Asset catalog | [ObjectStore](https://github.com/MolochDaGod/ObjectStore) | `objectstore.grudge-studio.com` |
+> | Binary CDN | GrudgeBuilder `workers/cdn/` | `assets.grudge-studio.com` |
+> | AI gateway | grudge-ai-hub | `ai.grudge-studio.com` |
+>
+> Fleet SSOT: `GrudgeBuilder/shared/fleet/manifest.ts`. Do **not** deploy this repo to the VPS unless you are explicitly maintaining legacy Warlords infrastructure.
+
+---
+
+## Legacy reference (archived)
+
+Full-stack microservices backend for **grudgewarlords.com** and **grudgestudio.com** (historical).
 
 Built with Node.js · Docker · MySQL 8 · Redis 7 · nginx · Solana · Cloudflare · Puter
 


### PR DESCRIPTION
## Problem

The External Health Check workflow has been failing every 5 minutes (run #1107+) because it probes retired VPS microservice URLs:
- \/health\ on subdomains that now redirect or no longer resolve (\ccount.grudge-studio.com\, \ssets-api.grudge-studio.com\)
- Legacy paths while production auth/API moved to **grudge-backend** (\/api/health\ works)

## Changes

1. **healthcheck.yml** — Monitor canonical fleet endpoints from \GrudgeBuilder/shared/fleet/manifest.ts\:
   - \id.grudge-studio.com/api/health\
   - \pi.grudge-studio.com/api/health\
   - \grudge-api-production-0d46.up.railway.app/api/health\
   - \objectstore.grudge-studio.com/health\
   - \i.grudge-studio.com/health\
   - Schedule: 5 min → 30 min

2. **deploy.yml** — Remove \push\ trigger; VPS deploy is \workflow_dispatch\ only

3. **README.md + AGENTS.md** — Retirement banner pointing to grudge-backend, GrudgeBuilder, ObjectStore

## Follow-up (manual)

- Archive this repo when no legacy VPS consumers remain
- \ssh grudge-vps\ → \docker compose down\ on old stack if still running
- Update grudge-dev-tool / dash references to grudge-backend